### PR TITLE
Fix already selected button state issues after restore

### DIFF
--- a/library/src/main/java/co/ceryle/radiorealbutton/RadioRealButton.java
+++ b/library/src/main/java/co/ceryle/radiorealbutton/RadioRealButton.java
@@ -399,7 +399,7 @@ public class RadioRealButton extends LinearLayout {
         if (hasAnimation)
             colorTransition(textView, c1, c2, duration);
         else
-            setTextColor(c2);
+            textView.setTextColor(c2);
     }
 
     private void colorTransition(final View v, int colorFrom, int colorTo, int duration) {

--- a/library/src/main/java/co/ceryle/radiorealbutton/RadioRealButtonGroup.java
+++ b/library/src/main/java/co/ceryle/radiorealbutton/RadioRealButtonGroup.java
@@ -83,9 +83,10 @@ public class RadioRealButtonGroup extends RoundedCornerLayout implements RadioRe
                     if (initialPosition != -1)
                         v_selectors.get(initialPosition).setVisibility(INVISIBLE);
                     v_selectors.get(position).setVisibility(VISIBLE);
+                    setPosition(position, false);
                     lastPosition = initialPosition = position;
-                }
-                setPosition(position, false);
+                } else
+                    setPosition(position, false);
             }
         }
         super.onRestoreInstanceState(state);


### PR DESCRIPTION
- Fix already selected button not being checked after restore
- Fix `textColor` attribute being overwritten with `textColorTo` for already selected button after restore