### PR TITLE
Add selector width

### DIFF
--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -108,6 +108,7 @@
         <attr name="rrbg_selectorBottom" format="boolean"/>
         <attr name="rrbg_selectorColor" format="color"/>
         <attr name="rrbg_selectorSize" format="dimension"/>
+        <attr name="rrbg_selectorWidth" format="dimension" />
         <attr name="rrbg_selectorBringToFront" format="boolean"/>
         <attr name="rrbg_selectorAboveOfBottomLine" format="boolean"/>
         <attr name="rrbg_selectorRadius" format="dimension"/>


### PR DESCRIPTION
<img width="332" alt="screen shot 2018-03-08 at 10 28 08 pm" src="https://user-images.githubusercontent.com/2828848/37164370-14447406-2320-11e8-97df-e8cf1389aa08.png">

Please refer the above image, where selector length is lesser than the actual tab size. To achieve the same we should be able to control the selector length. This PR adds that support to `RadioRealButtonGroup` with a new attribute `rrbg_selectorWidth `